### PR TITLE
Minor text fix: removes repeated word in Bias-Variance HTML 

### DIFF
--- a/code/bias-variance/index.html
+++ b/code/bias-variance/index.html
@@ -288,7 +288,7 @@
               <br /><br />
               In other words, we don’t want an underfit model, but we don’t want
               an overfit model either. We want something in between - something
-              with enough complexity to learn learn the generalizable patterns
+              with enough complexity to learn the generalizable patterns
               in our data.
               <br /><br />
               <span id="balance-def"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Just removes the repeated "learn" under the "**Finding a Balance**" section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
